### PR TITLE
feat: make all per-site settings configurable via .env file & unbound.d/ files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "servfail",
     "setpassword",
     "stripprefix",
+    "toplevel",
     "traefik",
     "Ubiquiti"
   ],

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dig -p 5300 @localhost cloudflare.com +dnssec
 directly connect to container:
 
 ```bash
-docker exec -it dns sh
+docker exec -it dns ash
 ```
 
 ## Deployment
@@ -43,10 +43,12 @@ docker exec -it dns sh
 
 - git clone this repo (or [download main branch as zip, then unzip](https://github.com/davidjenni/pi-hole-unbound/archive/refs/heads/main.zip))
 - Create your own *.prod.env file, use the checked in jenni.prod.env as starting point
-- start compose stack:
+- re-start compose stack (build & pull before stopping the already running DNS server!):
 
 ```bash
-docker compose --env-file your.prod.env up -d
+docker compose --env-file lan.prod.env build --pull && \
+docker compose --env-file lan.prod.env stop && \
+docker compose --env-file lan.prod.env up -d --wait && \
 docker compose ps
 ```
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -65,7 +65,7 @@ services:
       FTLCONF_dns_dnssec: "true"
       FTLCONF_dns_interface: "eth0"
       FTLCONF_dns_listeningMode: "BIND"
-      FTLCONF_dns_revServers: "PIHOLE_LOCAL_DNS_REVERSE_SERVERS"
+      FTLCONF_dns_revServers: "$PIHOLE_LOCAL_DNS_REVERSE_SERVERS"
       FTLCONF_dns_reply_host_force4: "true"
       FTLCONF_webserver_paths_prefix: "/pihole"
       # set webUI password later via:

--- a/lan.prod.env
+++ b/lan.prod.env
@@ -1,10 +1,12 @@
-# production .env settings for my local network: jenni.mgmt
+# production .env settings for my local network: .lan, .iot.lan, .mgmt.lan
+# the LAN specific address ranges and VLANS work for my local setup
 #
 # launch with:
-# docker compose --env-file jenni.prod.env up -d
+# docker compose --env-file lan.prod.env up -d
 
+PIHOLE_INSTANCE_NAME=pi-docker0
 PIHOLE_DNS_PORT=53
-PIHOLE_HOSTNAME=ns1.jenni.mgmt
+PIHOLE_HOSTNAME=${PIHOLE_INSTANCE_NAME}.mgmt.lan
 
 # https://docs.pi-hole.net/docker/configuration/?h=tz#environment-variables
 PIHOLE_TIMEZONE=America/Los_Angeles
@@ -14,4 +16,5 @@ PIHOLE_TIMEZONE=America/Los_Angeles
 # https://github.com/pi-hole/FTL/blob/bc185680fc2af2f7e21bd120f56749051207914f/src/config/validator.c#L366
 # // Each entry has to be of form "<enabled>,<ip-address>[/<prefix-len>],<server>[#<port>][,<domain>"]
 # The generated pihole.toml also does have a more in depth description of the format.
-PIHOLE_LOCAL_DNS_REVERSE_SERVERS=[true,10.0.10.0/24,10.0.10.1,jenni.mgmt]
+# For a list of servers, separate each entry with a semicolon `;`
+PIHOLE_LOCAL_DNS_REVERSE_SERVERS=true,10.0.10.0/24,10.0.10.1,lan;true,10.0.90.0/24,10.0.10.1,mgmt.lan;true,10.0.30.0/24,10.0.10.1,iot.lan

--- a/unbound/Dockerfile
+++ b/unbound/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:latest
 
 COPY unbound.conf /etc/unbound/unbound.conf
+COPY unbound.d/*.conf /etc/unbound/unbound.d/
 COPY startup.sh /etc/unbound/startup.sh
 
 RUN apk add --no-cache drill unbound \

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -4,8 +4,8 @@ server:
     interface: 0.0.0.0
     port: 5335
     do-ip4: yes
+    do-ip6: yes
     prefer-ip4: yes
-    do-ip6: no
     do-udp: yes
     do-tcp: yes
 
@@ -37,7 +37,7 @@ server:
     # Level 1: Gives operational information.
     # Level 2: Gives detailed operational information including short information per query.
     # Level 3: Gives query level information, output per query.
-    # Level 4:  Gives algorithm level information.
+    # Level 4: Gives algorithm level information.
     # Level 5: Logs client identification for cache misses.
     verbosity: 1
     use-syslog: no
@@ -46,18 +46,12 @@ server:
     log-servfail: yes
     # log-queries: yes
     # log-replies: yes
-
-    # link to local DNS and local domain:
-    private-domain: "jenni"
-    # local domain also doesn't participate in DNSSEC validation
-    domain-insecure: "jenni"
-
-    forward-zone:
-        name: "jenni"
-        forward-addr: 10.0.10.1
+    # log-local-actions: yes
 
 # remote control via unbound-control
 remote-control:
     control-enable: yes
     control-interface: 127.0.0.1
     control-use-cert: no
+
+include: "/etc/unbound/unbound.d/*.conf"

--- a/unbound/unbound.d/lan.local.conf
+++ b/unbound/unbound.d/lan.local.conf
@@ -1,0 +1,11 @@
+# see details in https://www.nlnetlabs.nl/documentation/unbound/unbound.conf/
+
+server:
+    # link to local DNS and local domain:
+    private-domain: "lan"
+    # local domain also doesn't participate in DNSSEC validation
+    domain-insecure: "lan"
+
+    forward-zone:
+        name: "lan"
+        forward-addr: 10.0.10.1


### PR DESCRIPTION
Also switched my local Unifi DNS to a more generic domain names: .lan, .mgmt.lan and .iot.lan
The one site-specific are the IP CIDR which are what my LAN uses: several 10.0.NN.1/24 ranges.