### PR TITLE
fix, breaking: remove explicitly set container names to avoid name conflict

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -42,11 +42,11 @@ jobs:
           echo "-- List containers:"
           docker ps --size
           echo "-- traefik logs:"
-          docker logs traefik
+          docker logs ns-traefik-1
           echo "-- unbound logs:"
-          docker logs dns
+          docker logs ns-dns-1
           echo "-- pihole logs:"
-          docker logs pihole
+          docker logs ns-pihole-1
 
       - name: Test Unbound DNS resolution
         env:
@@ -58,9 +58,9 @@ jobs:
           echo "-- Sleeping..."
           sleep 10
           echo "-- Unbound stats:"
-          docker exec -i dns unbound-control stats_noreset
+          docker exec -i ns-dns-1 unbound-control stats_noreset
           echo "-- Unbound cache dump:"
-          docker exec -i dns unbound-control dump_cache > $DUMP_CACHE_FILE
+          docker exec -i ns-dns-1 unbound-control dump_cache > $DUMP_CACHE_FILE
           cat $DUMP_CACHE_FILE | head -n 10
           echo "-- Unbound cache dump (last 10 lines):"
           tail -n 10 $DUMP_CACHE_FILE
@@ -70,9 +70,9 @@ jobs:
           echo "-- DNSSEC query:"
           dig -p 5300 @localhost microsoft.com +dnssec
           echo "-- pihole log:"
-          docker exec -i pihole tail -40  /var/log/pihole/pihole.log | tee $ARTIFACT_DIR/pihole.log
+          docker exec -i ns-pihole-1 tail -40  /var/log/pihole/pihole.log | tee $ARTIFACT_DIR/pihole.log
           echo "-- pihole log:"
-          docker exec -i pihole tail -40  /var/log/pihole/FTL.log | tee $ARTIFACT_DIR/FTL.log
+          docker exec -i ns-pihole-1 tail -40  /var/log/pihole/FTL.log | tee $ARTIFACT_DIR/FTL.log
 
       - name: Stop containers
         run: |

--- a/README.md
+++ b/README.md
@@ -34,22 +34,19 @@ dig -p 5300 @localhost cloudflare.com +dnssec
 directly connect to container:
 
 ```bash
-docker exec -it dns ash
+docker exec -it ns-dns-1 ash
 ```
 
 ## Deployment
 
 ### Manual deployment
 
-- git clone this repo (or [download main branch as zip, then unzip](https://github.com/davidjenni/pi-hole-unbound/archive/refs/heads/main.zip))
+- git clone this repo (or [download latest release as zip, then unzip](https://github.com/davidjenni/pi-hole-unbound/releases))
 - Create your own *.prod.env file, use the checked in jenni.prod.env as starting point
 - re-start compose stack (build & pull before stopping the already running DNS server!):
 
 ```bash
-docker compose --env-file lan.prod.env build --pull && \
-docker compose --env-file lan.prod.env stop && \
-docker compose --env-file lan.prod.env up -d --wait && \
-docker compose ps
+./deploy.sh
 ```
 
 ## TODOs

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
+name: ns
+
 services:
   traefik:
-    container_name: traefik
     image: traefik:v3.4
     command:
       - "--api.insecure=true"
@@ -32,7 +33,6 @@ services:
       - "traefik.enable=true"
 
   dns:
-    container_name: dns
     build:
       context: ./unbound/
       dockerfile: Dockerfile
@@ -51,7 +51,6 @@ services:
     restart: unless-stopped
 
   pihole:
-    container_name: pihole
     hostname: $PIHOLE_HOSTNAME
     image: pihole/pihole:latest
     networks:
@@ -69,9 +68,9 @@ services:
       FTLCONF_dns_reply_host_force4: "true"
       FTLCONF_webserver_paths_prefix: "/pihole"
       # set webUI password later via:
-      # > docker exec -it pihole pihole setpassword <password>
+      # > docker exec -it ns-pihole-1 pihole setpassword <password>
     volumes:
-      - ./pi-hole:/etc/pihole
+      - ~/etc-pihole:/etc/pihole
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.pihole.entrypoints=web"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo ">>-- Current running containers:" && \
+docker container ls && \
+echo ">>-- Building and pulling latest images..." && \
+docker compose --env-file lan.prod.env pull && \
+docker compose --env-file lan.prod.env build && \
+echo ">>-- Deploying new versions..." && \
+docker compose --env-file lan.prod.env stop && \
+docker compose --env-file lan.prod.env up -d --wait && \
+echo ">>-- Deployment complete. Current containers:" && \
+docker container ls -a && \
+echo ">>-- Current container stats:" && \
+docker compose --env-file lan.prod.env stats --no-stream


### PR DESCRIPTION
- not setting `container-name` attribute resolves the name conflict on rebuilding/re-deploying
- breaking: rename project to shorter name `ns`, now independent of the local git repo folder name this means for `docker exec`, the container name changes to e.g.: `ns-pihole-1`
- breaking: move pihole's mapped container to `~/etc-pihole`, no longer part of the repo to preserve state, move the repo-local folder: `mv ./pihole ~/etc-pihole`
- adding a `./deploy.sh` script to make deployments consistent and easier if e.g. sudo is required on docker host
- fixes #9